### PR TITLE
fix: make serverUrl always have the livekit cloud websocket server

### DIFF
--- a/src/components/media-room.tsx
+++ b/src/components/media-room.tsx
@@ -49,7 +49,7 @@ export function MediaRoom({ chatId, isVideo, isAudio }: MediaRoomProps) {
       audio={isAudio}
       token={token}
       connect={true}
-      serverUrl={process.env.NEXT_PUBLIC_LIVEKIT_URL}
+      serverUrl={process.env.NEXT_PUBLIC_LIVEKIT_URL!}
       data-lk-theme="default"
     >
       <VideoConference />


### PR DESCRIPTION
- fix: make serverUrl always have the livekit cloud websocket server